### PR TITLE
Bump eslint version to current

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "eslint-config-brunch",
+  "version": "1.0.0",
+  "lockfileVersion": 1
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "node"
   ],
   "peerDependencies": {
-    "eslint": "^3.14.1"
+    "eslint": "~4.3.0"
   },
   "homepage": "https://github.com/brunch/eslint-config-brunch#readme"
 }


### PR DESCRIPTION
This PR simply bumps the version of the eslint dependency from `^3.14.1` to `~4.3.0`. It seems that this is an easier way to allow dependencies to use the newest versions of the `eslint` package than to push a new patch every time the eslint version changes.

The `sass-brunch` package includes `eslint-config-brunch` as a dependency, and because of the stale dep version here it was not possible to bump the `eslint` version in `sass-brunch`. This PR would allow the `sass-brunch` package to continue using the main `brunch/eslint-config-brunch` branch here instead of needing to use a fork.

Thanks for the great work and for providing a useful tool to the community. It's my pleasure to be of assistance here.

Best,
Mike Zazaian