### PR TITLE
ecmaVersion should be a number

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: "2020",
+    ecmaVersion: 2020,
   },
   env: {
     node: true,


### PR DESCRIPTION
Recently eslint errors with "Parsing error: Invalid ecmaVersion" if ecmaVersion is a string